### PR TITLE
console_engine and crossterm update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "console_engine"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bc10090a2876c77c195977a1a9703d5675e775a7f50bc7d4b254e707460beb"
+checksum = "b05723615fd3ab8251764e161f1a6c65cce538d3d7902b94ee3290a0c5811e24"
 dependencies = [
  "crossterm",
  "unicode-width",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ lto = true
 [workspace.dependencies]
 bincode = "1.3.3"
 chrono = "0.4.24"
-console_engine = "2.5.1"
+console_engine = "2.6.0"
 crossbeam-channel = "0.5.7"
-crossterm = { version = "0.24.0", features = ["serde"] }
+crossterm = { version = "0.26.1", features = ["serde"] }
 laminar = "0.5.0"
 legion = "0.4.0"
 log = "0.4.17"

--- a/rustyhack_client/src/client_game.rs
+++ b/rustyhack_client/src/client_game.rs
@@ -2,7 +2,7 @@ mod client_updates_handler;
 mod input;
 mod screens;
 
-use console_engine::{ConsoleEngine, KeyCode, KeyModifiers};
+use console_engine::{ConsoleEngine, KeyCode, KeyEventKind, KeyModifiers};
 use crossbeam_channel::{Receiver, Sender};
 use crossterm::style::Color;
 use laminar::{Packet, SocketEvent};
@@ -118,5 +118,9 @@ pub(super) fn run(
 }
 
 fn should_quit(console: &ConsoleEngine) -> bool {
-    console.is_key_pressed_with_modifier(KeyCode::Char('q'), KeyModifiers::CONTROL)
+    console.is_key_pressed_with_modifier(
+        KeyCode::Char('q'),
+        KeyModifiers::CONTROL,
+        KeyEventKind::Press,
+    )
 }


### PR DESCRIPTION
Small update that supports key release events on windows. I was hoping to make use of the new release event to have smooth movement. I added an example to console_engine that I wanted to port here but couldn't get the movement to change. It wasn't flawless anyway so I'll leave it as just a version bump.

I was also hoping it'd fix the map glitch on startup but it didn't, not sure what causes that still.

This is the example if you want to see it: https://github.com/VincentFoulon80/console_engine/blob/master/examples/scroll-smooth.rs