### PR TITLE
chore: rust 2024 edition & dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,12 +57,12 @@ jobs:
         tar -cvzf rustyhack-client-ubuntu.tar.gz rustyhack-client
         tar -cvzf rustyhack-server-ubuntu.tar.gz rustyhack-server assets
     - name: Upload Artifact Client
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rustyhack-client-ubuntu
         path: rustyhack-client-ubuntu.tar.gz
     - name: Upload Artifact Server
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rustyhack-server-ubuntu
         path: rustyhack-server-ubuntu.tar.gz
@@ -89,12 +89,12 @@ jobs:
           tar -cvzf rustyhack-client-macos.tar.gz rustyhack-client
           tar -cvzf rustyhack-server-macos.tar.gz rustyhack-server assets
       - name: Upload Artifact Client
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rustyhack-client-macos
           path: rustyhack-client-macos.tar.gz
       - name: Upload Artifact Server
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rustyhack-server-macos
           path: rustyhack-server-macos.tar.gz
@@ -117,12 +117,12 @@ jobs:
           copy target\release\rustyhack_client.exe rustyhack-client.exe
           copy target\release\rustyhack_server.exe rustyhack-server.exe
       - name: Upload Artifact Client (win32)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rustyhack-client-win32
           path: rustyhack-client.exe
       - name: Upload Artifact Server (win32)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rustyhack-server-win32
           path: |
@@ -147,12 +147,12 @@ jobs:
           copy target\release\rustyhack_client.exe rustyhack-client.exe
           copy target\release\rustyhack_server.exe rustyhack-server.exe
       - name: Upload Artifact Client (win64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rustyhack-client-win64
           path: rustyhack-client.exe
       - name: Upload Artifact Server (win64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rustyhack-server-win64
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🧰 Maintenance
 - updated dependencies
+- updated rust edition to 2024
 - fixed new clippy warnings
 
 ## [v0.3.2]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "build_const"
@@ -82,9 +82,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -94,9 +94,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -109,16 +109,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -223,9 +223,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "erased-serde"
@@ -244,7 +244,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -308,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -380,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "lock_api"
@@ -396,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matrixmultiply"
@@ -452,7 +464,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -529,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "parking_lot"
@@ -576,7 +588,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.10",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -589,9 +601,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "portable-atomic-util"
@@ -610,27 +622,27 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -662,7 +674,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -711,11 +723,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -749,9 +761,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustyhack_client"
@@ -784,8 +796,8 @@ dependencies = [
  "rayon",
  "serde",
  "simplelog",
- "strum_macros 0.26.4",
- "uuid 1.12.1",
+ "strum_macros 0.27.1",
+ "uuid 1.15.1",
 ]
 
 [[package]]
@@ -806,14 +818,14 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "uuid 1.12.1",
+ "uuid 1.15.1",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scoped-tls-hkt"
@@ -829,29 +841,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -908,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -946,15 +958,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -970,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1005,14 +1017,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -1027,15 +1039,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1043,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -1059,17 +1071,17 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
  "serde",
 ]
 
@@ -1078,6 +1090,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1101,7 +1122,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -1123,7 +1144,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1176,6 +1197,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
@@ -1326,22 +1353,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
+name = "wit-bindgen-rt"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "byteorder",
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
  "crossbeam-channel",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
 ]
 
@@ -654,8 +654,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy",
 ]
 
 [[package]]
@@ -665,7 +676,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -678,12 +699,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -812,7 +842,7 @@ dependencies = [
  "log",
  "message-io",
  "ndarray",
- "rand",
+ "rand 0.9.0",
  "rayon",
  "rustyhack_lib",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-package.edition = "2021"
+package.edition = "2024"
 resolver = "2"
 members = [
     "rustyhack_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ legion = "0.4.0"
 log = "0.4.26"
 message-io = { version = "0.18.3", default-features = false, features = ["tcp"] }
 ndarray = { version = "0.16.1", features = ["rayon", "serde"] }
-rand = "0.8.5"
+rand = "0.9.0"
 rayon = "1.10.0"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,20 @@ lto = true
 
 [workspace.dependencies]
 bincode = "1.3.3"
-chrono = "0.4.39"
+chrono = "0.4.40"
 console_engine = "2.6.1"
 crossbeam-channel = "0.5.14"
 crossterm = { version = "0.26.1", features = ["serde"] }
 laminar = "0.5.0"
 legion = "0.4.0"
-log = "0.4.25"
+log = "0.4.26"
 message-io = { version = "0.18.3", default-features = false, features = ["tcp"] }
 ndarray = { version = "0.16.1", features = ["rayon", "serde"] }
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.11.1"
-serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.137"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 simplelog = "0.12.2"
-strum_macros = "0.26.4"
-uuid = { version = "1.12.1", features = ["serde", "v4"] }
+strum_macros = "0.27.1"
+uuid = { version = "1.15.1", features = ["serde", "v4"] }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Currently, the following functionality is defined entirely by text or json files
 - **spawns** - *.json* - Spawn locations of monsters. There should be one spawn file per map.
 
 ## Building from source
-1. Install latest version of [rust](https://www.rust-lang.org/) (most recently confirmed working `1.84.0`)
+1. Install latest version of [rust](https://www.rust-lang.org/) (most recently confirmed working `1.85.0`)
 2. Download this repository
 3. Run `cargo build` in the repository root directory
 4. Copy `assets` directory into `target/debug` directory

--- a/rustyhack_client/src/client_game.rs
+++ b/rustyhack_client/src/client_game.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use crate::client_consts::{
     CLIENT_CLEANUP_TICK, GAME_TITLE, INITIAL_CONSOLE_HEIGHT, INITIAL_CONSOLE_WIDTH, TARGET_FPS,
 };
-use crate::client_game::screens::{draw_screens, SidebarState};
+use crate::client_game::screens::{SidebarState, draw_screens};
 use input::commands::movement;
 
 use crate::client_network_messages::{

--- a/rustyhack_client/src/client_game/input/commands/look.rs
+++ b/rustyhack_client/src/client_game/input/commands/look.rs
@@ -108,6 +108,6 @@ pub(super) fn return_visible_entity_at(
 
     match entity {
         None => entity_name,
-        Some(entity) => entity.1 .5.clone(),
+        Some(entity) => entity.1.5.clone(),
     }
 }

--- a/rustyhack_client/src/client_game/screens/bottom_text_window.rs
+++ b/rustyhack_client/src/client_game/screens/bottom_text_window.rs
@@ -1,6 +1,6 @@
 use crate::client_consts::DEFAULT_BG_COLOUR;
-use console_engine::screen::Screen;
 use console_engine::ConsoleEngine;
+use console_engine::screen::Screen;
 use crossterm::style::Color;
 use rustyhack_lib::utils::math::i32_from_usize;
 

--- a/rustyhack_client/src/client_game/screens/drop_item_choice.rs
+++ b/rustyhack_client/src/client_game/screens/drop_item_choice.rs
@@ -1,5 +1,5 @@
-use console_engine::screen::Screen;
 use console_engine::ConsoleEngine;
+use console_engine::screen::Screen;
 use rustyhack_lib::ecs::item::get_item_name;
 use rustyhack_lib::ecs::player::Player;
 

--- a/rustyhack_client/src/client_game/screens/side_status_bar.rs
+++ b/rustyhack_client/src/client_game/screens/side_status_bar.rs
@@ -1,6 +1,6 @@
 use crate::client_consts::DEFAULT_BG_COLOUR;
-use console_engine::screen::Screen;
 use console_engine::ConsoleEngine;
+use console_engine::screen::Screen;
 use crossterm::style::Color;
 use rustyhack_lib::ecs::item::get_item_name;
 use rustyhack_lib::ecs::player::Player;

--- a/rustyhack_client/src/client_game/screens/stat_up_choice.rs
+++ b/rustyhack_client/src/client_game/screens/stat_up_choice.rs
@@ -1,5 +1,5 @@
-use console_engine::screen::Screen;
 use console_engine::ConsoleEngine;
+use console_engine::screen::Screen;
 use rustyhack_lib::ecs::player::Player;
 
 pub(super) fn draw(player: &Player, console: &ConsoleEngine, viewport_width: u32) -> Screen {

--- a/rustyhack_client/src/client_game/screens/top_status_bar.rs
+++ b/rustyhack_client/src/client_game/screens/top_status_bar.rs
@@ -1,5 +1,5 @@
 use console_engine::screen::Screen;
-use console_engine::{pixel, ConsoleEngine};
+use console_engine::{ConsoleEngine, pixel};
 use rustyhack_lib::ecs::player::Player;
 use rustyhack_lib::utils::math::i32_from;
 

--- a/rustyhack_client/src/client_network_messages/map_downloader.rs
+++ b/rustyhack_client/src/client_network_messages/map_downloader.rs
@@ -75,7 +75,9 @@ fn deserialize_all_maps_reply(data: &[u8]) -> Option<AllMaps> {
                 info!("AllMaps data downloaded successfully.");
                 Some(all_maps)
             } else {
-                warn!("Deserialized message from server was not valid AllMaps data, will request again.");
+                warn!(
+                    "Deserialized message from server was not valid AllMaps data, will request again."
+                );
                 None
             }
         }

--- a/rustyhack_server/src/game/combat.rs
+++ b/rustyhack_server/src/game/combat.rs
@@ -91,8 +91,8 @@ pub(super) fn resolve_combat(
 }
 
 fn calculate_damage_dealt(attacker_weapon_damage_range: &Range<f32>, attacker_str: f32) -> f32 {
-    let mut rng = rand::thread_rng();
-    let attacker_weapon_damage = rng.gen_range(attacker_weapon_damage_range.clone());
+    let mut rng = rand::rng();
+    let attacker_weapon_damage = rng.random_range(attacker_weapon_damage_range.clone());
     debug!(
         "Weapon damage before strength modifier: {}",
         attacker_weapon_damage
@@ -109,9 +109,9 @@ fn check_attack_success(
     attacker_weapon_accuracy: f32,
     defender_dex: f32,
 ) -> bool {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let combat_accuracy = attacker_weapon_accuracy
         + ((100.0 - attacker_weapon_accuracy) * (attacker_dex / 100.0))
         - ((100.0 - attacker_weapon_accuracy) * (defender_dex / 100.0));
-    combat_accuracy >= rng.gen_range(0.0..=100.0)
+    combat_accuracy >= rng.random_range(0.0..=100.0)
 }

--- a/rustyhack_server/src/game/ecs/queries/drop_item.rs
+++ b/rustyhack_server/src/game/ecs/queries/drop_item.rs
@@ -6,7 +6,7 @@ use rustyhack_lib::consts::{DEFAULT_ITEM_COLOUR, DEFAULT_ITEM_ICON};
 use rustyhack_lib::ecs::components::{
     DisplayDetails, Inventory, ItemDetails, PlayerDetails, Position,
 };
-use rustyhack_lib::ecs::item::{get_item_name, Item};
+use rustyhack_lib::ecs::item::{Item, get_item_name};
 use rustyhack_lib::network::packets::PositionMessage;
 use uuid::Uuid;
 

--- a/rustyhack_server/src/game/ecs/queries/pickup_item.rs
+++ b/rustyhack_server/src/game/ecs/queries/pickup_item.rs
@@ -3,7 +3,7 @@ use crossbeam_channel::Sender;
 use laminar::Packet;
 use legion::{IntoQuery, World};
 use rustyhack_lib::ecs::components::{Inventory, ItemDetails, PlayerDetails, Position};
-use rustyhack_lib::ecs::item::{get_item_name, Item};
+use rustyhack_lib::ecs::item::{Item, get_item_name};
 use rustyhack_lib::network::packets::PositionMessage;
 
 pub(crate) fn pickup_item(

--- a/rustyhack_server/src/game/ecs/queries/player_joined.rs
+++ b/rustyhack_server/src/game/ecs/queries/player_joined.rs
@@ -44,7 +44,10 @@ pub(crate) fn join_player(
             should_create_new_player = false;
             break;
         } else if player_details.player_name == name && player_details.currently_online {
-            warn!("Player join request from {} for existing player that's currently online ({} at {}).", &client_addr, &name, &player_details.client_addr);
+            warn!(
+                "Player join request from {} for existing player that's currently online ({} at {}).",
+                &client_addr, &name, &player_details.client_addr
+            );
             let response = serialize(&ServerMessage::PlayerAlreadyOnline).unwrap_or_else(|err| {
                 error!(
                     "Failed to serialize player already online response, error: {}",

--- a/rustyhack_server/src/game/ecs/systems/monster_systems.rs
+++ b/rustyhack_server/src/game/ecs/systems/monster_systems.rs
@@ -4,7 +4,7 @@ use crate::game::monsters::{movement, spawning};
 use crate::game::players::PlayersPositions;
 use legion::systems::CommandBuffer;
 use legion::world::SubWorld;
-use legion::{maybe_changed, system, Entity, Query};
+use legion::{Entity, Query, maybe_changed, system};
 use rustyhack_lib::consts::{DEAD_MAP, DEFAULT_ITEM_COLOUR, DEFAULT_ITEM_ICON};
 use rustyhack_lib::ecs::components::{
     Dead, DisplayDetails, Inventory, ItemDetails, MonsterDetails, Position, Stats,

--- a/rustyhack_server/src/game/ecs/systems/position_systems.rs
+++ b/rustyhack_server/src/game/ecs/systems/position_systems.rs
@@ -1,13 +1,13 @@
 use crate::game::map::state::EntityPositionMap;
 use crate::game::map::{state, tiles};
 use legion::systems::CommandBuffer;
-use legion::{maybe_changed, system, Entity};
+use legion::{Entity, maybe_changed, system};
 use rustyhack_lib::background_map::AllMaps;
 use rustyhack_lib::consts::DEAD_MAP;
 use rustyhack_lib::ecs::components::{
     Dead, DisplayDetails, ItemDetails, MonsterDetails, PlayerDetails, Position,
 };
-use rustyhack_lib::ecs::item::{get_item_name, Item};
+use rustyhack_lib::ecs::item::{Item, get_item_name};
 use rustyhack_lib::utils::math::{i32_from, u32_from};
 
 #[system(par_for_each)]

--- a/rustyhack_server/src/game/map/state.rs
+++ b/rustyhack_server/src/game/map/state.rs
@@ -58,7 +58,10 @@ pub(crate) fn remove_entity_at(map: &mut MapState, entity: &EntityType, x: u32, 
         }
         Some((index, _entity_type)) => match map.get_mut((y as usize, x as usize)) {
             None => {
-                warn!("Tried to remove entity at invalid position, x: {}, y: {}, will try to continue.", x, y);
+                warn!(
+                    "Tried to remove entity at invalid position, x: {}, y: {}, will try to continue.",
+                    x, y
+                );
             }
             Some(entity_vec) => {
                 entity_vec.remove(index);
@@ -85,7 +88,10 @@ pub(crate) fn is_colliding_with_entity(x: u32, y: u32, map_state: &MapState) -> 
     } else {
         let defending_entity = match &map_state.get((y as usize, x as usize)) {
             None => {
-                warn!("Tried to check for entity collision at invalid position, x: {}, y: {}, will try to continue.", x, y);
+                warn!(
+                    "Tried to check for entity collision at invalid position, x: {}, y: {}, will try to continue.",
+                    x, y
+                );
                 None
             }
             Some(entity_vec) => entity_vec.par_iter().find_any(|entity_type| {

--- a/rustyhack_server/src/game/map/tiles.rs
+++ b/rustyhack_server/src/game/map/tiles.rs
@@ -1,9 +1,9 @@
 use crate::consts;
 use crate::game::map::array_utils;
 use ndarray::Array2;
-use rustyhack_lib::background_map::tiles::{Collidable, Tile};
 use rustyhack_lib::background_map::AllMaps;
-use rustyhack_lib::background_map::{character_map, BackgroundMap};
+use rustyhack_lib::background_map::tiles::{Collidable, Tile};
+use rustyhack_lib::background_map::{BackgroundMap, character_map};
 use rustyhack_lib::utils::file;
 use std::collections::HashMap;
 use std::path::Path;

--- a/rustyhack_server/src/game/monsters/movement.rs
+++ b/rustyhack_server/src/game/monsters/movement.rs
@@ -17,28 +17,28 @@ pub(crate) fn move_towards_target(monster_position: &mut Position, target_positi
 
     if (diff_x.abs() >= 1 && diff_y.abs() >= 1) || (diff_x == 0 && diff_y == 0) {
         //far away, move randomly towards
-        let mut rng = rand::thread_rng();
-        if rng.gen::<bool>() {
+        let mut rng = rand::rng();
+        if rng.random::<bool>() {
             new_pos_x = move_towards(diff_x, monster_position_x);
         } else {
             new_pos_y = move_towards(diff_y, monster_position_y);
         }
     } else if diff_x.abs() > 1 && diff_y.abs() == 0 {
         //in line, should mostly move towards, but sometimes randomly
-        let mut rng = rand::thread_rng();
-        if rng.gen_range(1..=6) > 1 {
+        let mut rng = rand::rng();
+        if rng.random_range(1..=6) > 1 {
             new_pos_x = move_towards(diff_x, monster_position_x);
-        } else if rng.gen::<bool>() {
+        } else if rng.random::<bool>() {
             new_pos_y = move_towards(diff_y + 1, monster_position_y);
         } else {
             new_pos_y = move_towards(diff_y - 1, monster_position_y);
         }
     } else if diff_x.abs() == 0 && diff_y.abs() > 1 {
         //in line, should mostly move towards, but sometimes randomly
-        let mut rng = rand::thread_rng();
-        if rng.gen_range(1..=6) > 1 {
+        let mut rng = rand::rng();
+        if rng.random_range(1..=6) > 1 {
             new_pos_y = move_towards(diff_y, monster_position_y);
-        } else if rng.gen::<bool>() {
+        } else if rng.random::<bool>() {
             new_pos_x = move_towards(diff_x + 1, monster_position_x);
         } else {
             new_pos_x = move_towards(diff_x - 1, monster_position_x);
@@ -99,8 +99,8 @@ fn move_towards(diff: i32, position: i32) -> i32 {
 pub(crate) fn move_randomly(monster_position: &mut Position) {
     let mut velocity_x = 0;
     let mut velocity_y = 0;
-    let mut rng = rand::thread_rng();
-    let random_pick: u8 = rng.gen_range(1..=4);
+    let mut rng = rand::rng();
+    let random_pick: u8 = rng.random_range(1..=4);
 
     if random_pick == 1 {
         velocity_x = 1;

--- a/rustyhack_server/src/game/monsters/spawning.rs
+++ b/rustyhack_server/src/game/monsters/spawning.rs
@@ -2,12 +2,12 @@ use crate::consts;
 use crate::game::map::spawns::{AllSpawnCounts, AllSpawnsMap, PositionWithoutMap};
 use legion::systems::CommandBuffer;
 use legion::World;
-use rand::prelude::SliceRandom;
 use rand::Rng;
 use rustyhack_lib::ecs::components::{DisplayDetails, Inventory, MonsterDetails, Position, Stats};
 use rustyhack_lib::ecs::monster::AllMonsterDefinitions;
 use std::collections::HashMap;
 use std::process;
+use rand::prelude::IndexedRandom;
 use uuid::Uuid;
 
 pub(crate) fn count_monsters_needing_respawn(
@@ -88,8 +88,8 @@ pub(crate) fn respawn_monsters(
 
 fn should_respawn_this_tick() -> bool {
     //random chance for respawning each chick
-    let mut rng = rand::thread_rng();
-    consts::TICK_SPAWN_CHANCE_PERCENTAGE >= rng.gen_range(0..=101)
+    let mut rng = rand::rng();
+    consts::TICK_SPAWN_CHANCE_PERCENTAGE >= rng.random_range(0..=101)
 }
 
 pub(crate) fn spawn_initial_monsters(
@@ -165,7 +165,7 @@ fn spawn_single_monster(
         if monster_spawn_positions.monster_type.eq(monster_type) {
             random_spawn_position = *monster_spawn_positions
                 .spawn_positions
-                .choose(&mut rand::thread_rng())
+                .choose(&mut rand::rng())
                 .unwrap();
 
             let position = Position {

--- a/rustyhack_server/src/game/monsters/spawning.rs
+++ b/rustyhack_server/src/game/monsters/spawning.rs
@@ -1,13 +1,13 @@
 use crate::consts;
 use crate::game::map::spawns::{AllSpawnCounts, AllSpawnsMap, PositionWithoutMap};
-use legion::systems::CommandBuffer;
 use legion::World;
+use legion::systems::CommandBuffer;
 use rand::Rng;
+use rand::prelude::IndexedRandom;
 use rustyhack_lib::ecs::components::{DisplayDetails, Inventory, MonsterDetails, Position, Stats};
 use rustyhack_lib::ecs::monster::AllMonsterDefinitions;
 use std::collections::HashMap;
 use std::process;
-use rand::prelude::IndexedRandom;
 use uuid::Uuid;
 
 pub(crate) fn count_monsters_needing_respawn(


### PR DESCRIPTION
- update to rust edition 2024
- update dependencies
- fix clippy warnings
- fix github upload-artifact deprecated version